### PR TITLE
re-raising too early in job

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -101,9 +101,9 @@ class Job < ActiveRecord::Base
 			end
 			script_file.close
 	rescue Exception => e
-		raise e
 		job.update_attribute(:msg, e.message)
 		job.update_attribute(:status, "Failed")
+		raise e
 	end
 
   end


### PR DESCRIPTION
I'm having problems with resque jobs failing and not updating the job state:

  http://pastie.org/2404150

Looks like raise needs to be moved below:

```
   rescue Exception => e
-    raise e
     job.update_attribute(:msg, e.message)
     job.update_attribute(:status, "Failed")
+    raise e
```
