### PR TITLE
Change chef-vpc-toolkit version to 2.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
       multi_json (~> 1.0)
     arel (2.2.1)
     builder (3.0.0)
-    chef-vpc-toolkit (2.7.1)
+    chef-vpc-toolkit (2.8.1)
       builder
       json
       rake


### PR DESCRIPTION
The origional version 2.7.1 was conflicting with the version
quoted in openstack_vpc/config/TOOLKIT_VERSION

While running a test, jobs were failing with the error

Chef VPC Toolkit Version: 2.8.1
can't activate chef-vpc-toolkit (= 2.8.1), already activated chef-vpc-toolkit-2.7.1. Make sure all dependencies are added to Gemfile.
(See full trace by running task with --trace)
FAILURE_MSG=Invalid JSON config file(s).

this change fixes the problem
Tested on Fedora 16, ruby 1.9.2 with rvm
